### PR TITLE
Add habitat plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 /target
 **/*.rs.bk
+results/

--- a/README.md
+++ b/README.md
@@ -4,13 +4,27 @@ A git fsmonitor hook written in Rust.
 
 ## Installation
 
-Install the tool:
+### Via Homebrew
 
-`brew tap jgavris/rs-git-fsmonitor https://github.com/jgavris/rs-git-fsmonitor.git && brew install rs-git-fsmonitor`
+[Homebrew](https://brew.sh/) is the recommended way to install in Mac environments:
 
-Configure git repository to use the tool (run in desired large git repository):
+```bash
+brew tap jgavris/rs-git-fsmonitor https://github.com/jgavris/rs-git-fsmonitor.git && brew install rs-git-fsmonitor
 
-`git config core.fsmonitor rs-git-fsmonitor`
+# Configure git repository to use the tool (run in desired large git repository):
+git config core.fsmonitor rs-git-fsmonitor
+```
+
+### Via Habitat
+
+[Habitat](https://habitat.sh) is the recommended way to install in Linux environments: 
+
+```bash
+hab pkg install jgavris/rs-git-fsmonitor
+
+# Configure git repository to use the tool (run in desired large git repository):
+git config --global core.fsmonitor "$(hab pkg path jgavris/rs-git-fsmonitor)/bin/rs-git-fsmonitor"
+```
 
 ## Purpose
 

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,0 +1,23 @@
+pkg_name=rs-git-fsmonitor
+pkg_origin=jgavris
+pkg_version="0.1.1"
+pkg_maintainer="Jason Gavris <jgavris@gmail.com>"
+pkg_license=("MIT")
+pkg_upstream_url="https://github.com/jgavris/rs-git-fsmonitor"
+pkg_deps=(
+  core/glibc
+  core/gcc-libs
+  jarvus/watchman
+)
+pkg_build_deps=(
+  core/rust
+)
+pkg_bin_dirs=(bin)
+
+do_build() {
+  LD_LIBRARY_PATH="$LD_RUN_PATH" cargo build --release
+}
+
+do_install() {
+  cargo install --root "${pkg_prefix}"
+}


### PR DESCRIPTION
This provides an easy way to build/ship/install this binary to environments that have the [hab](https://www.habitat.sh/) binary:

```bash
hab pkg install -b jarvus/rs-git-fsmonitor
```

You can test out doing a build yourself quickly on Mac or Linux:

```bash
# install hab binary
curl -s https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash

hab pkg build ./rs-git-fsmonitor
```

`jarvus` is my origin that I've published a build under to use for now: https://bldr.habitat.sh/#/pkgs/jarvus/rs-git-fsmonitor/latest

If you're interested in merging this, you could register a `jgavris` origin at https://bldr.habitat.sh and configure habitat's public builder service to watch your master branch via github so the packages get updated automatically and you never have to worry about habitat again. I could do some additional work on the plan to have it determine its version automatically from your git tags.
