### PR TITLE
chore: bump habitat package version to 0.1.2

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=rs-git-fsmonitor
 pkg_origin=jgavris
-pkg_version="0.1.1"
+pkg_version="0.1.2"
 pkg_maintainer="Jason Gavris <jgavris@gmail.com>"
 pkg_license=("MIT")
 pkg_upstream_url="https://github.com/jgavris/rs-git-fsmonitor"


### PR DESCRIPTION
After merging, please promote the new build to stable: https://bldr.habitat.sh/#/pkgs/jgavris/rs-git-fsmonitor/latest