### PR TITLE
Features/habitat upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,6 @@ git config core.fsmonitor rs-git-fsmonitor
 # Install and link packages
 sudo hab pkg install --binlink jgavris/rs-git-fsmonitor
 
-# Ensure service directory exists and is writable
-sudo mkdir -p /hab/svc/watchman/var
-sudo chmod o+rwx /hab/svc/watchman/var
-
 # Configure git repository to use the tool (run in desired large git repository):
 git config --global core.fsmonitor rs-git-fsmonitor
 ```

--- a/README.md
+++ b/README.md
@@ -21,9 +21,7 @@ git config core.fsmonitor rs-git-fsmonitor
 
 ```bash
 # Install and link packages
-sudo hab pkg install jgavris/rs-git-fsmonitor
-sudo hab pkg binlink jgavris/rs-git-fsmonitor
-sudo hab pkg binlink jarvus/watchman
+sudo hab pkg install --binlink jgavris/rs-git-fsmonitor
 
 # Ensure service directory exists and is writable
 sudo mkdir -p /hab/svc/watchman/var

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -19,5 +19,5 @@ do_build() {
 }
 
 do_install() {
-  cargo install --root "${pkg_prefix}"
+  cargo install --path . --root "${pkg_prefix}"
 }

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -5,6 +5,7 @@ pkg_maintainer="Jason Gavris <jgavris@gmail.com>"
 pkg_license=("MIT")
 pkg_upstream_url="https://github.com/jgavris/rs-git-fsmonitor"
 pkg_deps=(
+  core/bash
   core/glibc
   core/gcc-libs
   jarvus/watchman
@@ -20,4 +21,23 @@ do_build() {
 
 do_install() {
   cargo install --path . --root "${pkg_prefix}"
+
+  build_line "Generating wrapper script for portable execution"
+  pushd "${pkg_prefix}/bin" > /dev/null
+  mkdir "../bin.real"
+  mv -v "rs-git-fsmonitor" "../bin.real/rs-git-fsmonitor"
+
+  cat <<EOF > "rs-git-fsmonitor"
+#!$(pkg_path_for core/bash)/bin/bash -e
+
+set -a
+.  ${pkg_prefix}/RUNTIME_ENVIRONMENT
+set +a
+
+exec ${pkg_prefix}/bin.real/rs-git-fsmonitor "\$@"
+EOF
+
+  chmod -v 755 "rs-git-fsmonitor"
+
+  popd > /dev/null
 }


### PR DESCRIPTION
This takes advantage of some newer features in Habitat to simplify the install and make it more portable

Updates to the `jarvus/watchman` plan use the new `install` hook to make sure everything is automatically set up at install time, and this plan generates a wrapper script to export that ensure the habitat environment (with proper watchman executable on path as well as its deps) is always present when you invoke `rs-git-fsmonitor` directly rather that through Habitat

This new build can be installed from my origin right now to test:

```bash
hab pkg install --binlink jarvus/rs-git-fsmonitor
```