### PR TITLE
fix: remove --global from habitat git config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ sudo mkdir -p /hab/svc/watchman/var
 sudo chmod o+rwx /hab/svc/watchman/var
 
 # Configure git repository to use the tool (run in desired large git repository):
-git config --global core.fsmonitor rs-git-fsmonitor
+git config core.fsmonitor rs-git-fsmonitor
 ```
 
 ## Purpose


### PR DESCRIPTION
The other example doesn't use --global and the comment above describes it as being applied to a particular repository