### PR TITLE
README: set habitat channel to unstable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ git config core.fsmonitor rs-git-fsmonitor
 
 ```bash
 # Install and link packages
-sudo hab pkg install --binlink jgavris/rs-git-fsmonitor
+sudo hab pkg install --binlink jgavris/rs-git-fsmonitor --channel unstable
 
 # Configure git repository to use the tool (run in desired large git repository):
 git config core.fsmonitor rs-git-fsmonitor

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ git config core.fsmonitor rs-git-fsmonitor
 
 ```bash
 # Install and link packages
-sudo hab pkg install --binlink jgavris/rs-git-fsmonitor --channel unstable
+sudo hab pkg install --binlink --channel unstable jgavris/rs-git-fsmonitor
 
 # Configure git repository to use the tool (run in desired large git repository):
 git config core.fsmonitor rs-git-fsmonitor


### PR DESCRIPTION
The `hab` I just downloaded defaults to the stable channel, but there are no stable releases for this package. Use the only channel that exists.